### PR TITLE
Wavelength range

### DIFF
--- a/wand/frontend/wand_server.py
+++ b/wand/frontend/wand_server.py
@@ -301,7 +301,7 @@ class WandServer:
                 try:
                     range_ = laser_conf.get("wavelength_range")
                     self.wlm.set_wavelength_range(range_)
-                except KeyError:
+                except WLMException:
                     pass
 
                 await asyncio.sleep(self.config["switch"]["dead_time"])

--- a/wand/frontend/wand_server.py
+++ b/wand/frontend/wand_server.py
@@ -25,7 +25,7 @@ from sipyco.common_args import (simple_network_args, bind_address_from_args,
 from sipyco.asyncio_tools import atexit_register_coroutine
 
 from wand.drivers.leoni_switch import LeoniSwitch
-from wand.drivers.high_finesse import WLM
+from wand.drivers.high_finesse import WLM, WLMException
 from wand.drivers.ni_osa import NiOSA
 from wand.tools import (load_config, backup_config, regular_config_backup,
                         get_config_path, WLMMeasurementStatus)


### PR DESCRIPTION
expected behaviour: wand_server should work even if the config file is supposed to work without specifying a wavelength range (if not, what should they be for a WS7?).

actual behaviour: it dies because a WLMException is raised when wand_server is looking for a KeyError (the underlying KeyError is converted to a WLMException inside the HF driver, so I assume this did work in a previous iteration)

@cjbe (a) what are the wavelength ranges for (b) can you cast an eye over this and merge if the fix looks appropriate? I haven't fully understood what these changes were supposed to do so hard to judge