### PR TITLE
Add # to colours - make compatible with dependencies

### DIFF
--- a/wand/gui.py
+++ b/wand/gui.py
@@ -35,16 +35,16 @@ class LaserDisplay:
         self.layout = pg.GraphicsLayoutWidget(border=(80, 80, 80))
 
         # create widgets
-        self.colour = "ffffff"  # will be set later depending on laser colour
+        self.colour = "#FFFFFF"  # will be set later depending on laser colour
 
         self.detuning = pg.LabelItem("")
-        self.detuning.setText("-", color="ffffff", size="64pt")
+        self.detuning.setText("-", color="#FFFFFF", size="64pt")
 
         self.frequency = pg.LabelItem("")
-        self.frequency.setText("-", color="ffffff", size="12pt")
+        self.frequency.setText("-", color="#FFFFFF", size="12pt")
 
         self.name = pg.LabelItem("")
-        self.name.setText(display_name, color="ffffff", size="32pt")
+        self.name.setText(display_name, color="#FFFFFF", size="32pt")
 
         self.osa = pg.PlotItem()
         self.osa.hideAxis('bottom')
@@ -162,11 +162,11 @@ class LaserDisplay:
 
         else:
             self.colour = self._gui.laser_db[self.laser].get("display_colour",
-                                                             "7c7c7c")
+                                                             "#7C7C7C")
             if self.colour == "red":
-                self.colour = "ff5555"
+                self.colour = "#FF5555"
             elif self.colour == "blue":
-                self.colour = "5555ff"
+                self.colour = "#5555FF"
 
             self.name.setText(self.display_name,
                               color=self.colour,
@@ -393,15 +393,15 @@ class LaserDisplay:
         elif status == WLMMeasurementStatus.UNDER_EXPOSED:
             freq = "-"
             detuning = "Low"
-            colour = "ff9900"
+            colour = "#FF9900"
         elif status == WLMMeasurementStatus.OVER_EXPOSED:
             freq = "-"
             detuning = "High"
-            colour = "ff9900"
+            colour = "#FF9900"
         else:
             freq = "-"
             detuning = "Error"
-            colour = "ff9900"
+            colour = "#FF9900"
 
         self.frequency.setText(freq, color=colour)
         self.detuning.setText(detuning, color=colour)


### PR DESCRIPTION
[Make colour strings compatible with updated dependencies 
Tested with python3.8.12 and python3.9.13](https://github.com/OxfordIonTrapGroup/wand/pull/50)

I've embarrassingly missed one of the colours!
