### PR TITLE
Add support for other actuators

### DIFF
--- a/wand/drivers/high_finesse.py
+++ b/wand/drivers/high_finesse.py
@@ -80,7 +80,7 @@ class WLM:
         self.wlm_fw_rev = lib.GetWLMVersion(2)
         self.wlm_fw_build = lib.GetWLMVersion(3)
 
-        if self.wlm_model < 5 or self.wlm_model > 8:
+        if self.wlm_model < 5 or self.wlm_model > 9:
             raise WLMException("Unrecognised WLM model: {}".format(
                 self.wlm_model))
 

--- a/wand/frontend/wand_server.py
+++ b/wand/frontend/wand_server.py
@@ -230,8 +230,10 @@ class WandServer:
                 v_pzt_max = conf.get("v_pzt_max", 100)
                 v_pzt_min = conf.get("v_pzt_min", 25)
 
-                await asyncio.wait({self.wake_locks[laser].wait()},
-                                   timeout=poll_time)
+                await asyncio.wait(
+                    {asyncio.create_task(self.wake_locks[laser].wait())},
+                    timeout=poll_time
+                )
                 self.wake_locks[laser].clear()
 
                 if timeout is not None and time.time() > (locked_at + timeout):

--- a/wand/server.py
+++ b/wand/server.py
@@ -313,7 +313,7 @@ class ControlInterface:
         capture_range = _validate_numeric(capture_range, "capture_range")
 
         laser_db = self._server.laser_db
-        laser_db[laser]["lock_gain"] = abs(gain)
+        laser_db[laser]["lock_gain"] = gain
         laser_db[laser]["lock_poll_time"] = abs(poll_time)
         laser_db[laser]["lock_capture_range"] = abs(capture_range)
 


### PR DESCRIPTION
Make actuator configurable. If unconfigured, defaults to piezo as before, keeping backwards compatibility.