### PR TITLE
Implement a proper ping rpc method

### DIFF
--- a/wand/server.py
+++ b/wand/server.py
@@ -55,8 +55,17 @@ class ControlInterface:
         if not self._server.laser_db.raw_view[laser]["host"]:
             raise ValueError("No controller found for '{}'".format(laser))
 
-    def ping(self):
-        return True
+    def ping(self) -> bool:
+        """ Ping the connected wavemeter.
+
+        :return: returns True if in simulation mode or the wavemeter
+        is responsive, returns False if the wavemeter returns an error.
+        """
+        if self._server.wlm.simulation:
+            return True
+        if self._server.wlm.lib.GetWLMVersion(0) > 0:
+            return True
+        return False
 
     async def get_freq(self, laser, age=0, priority=3, get_osa_trace=False,
                        blocking=True, mute=False, offset_mode=False):


### PR DESCRIPTION
The ping method now returns True if it can reach the wavemeter or if it is in simulation mode, and False otherwise.

This allows a client to check whether the wavemeter (and not just wand_server) can actually be reached. I chose to make a call to a function (GetWLMVersion) that is wavemeter specific, but independent of the current state of the wavemeter. In particular, this allows artiq (if wand_server is configured as an artiq controller) to terminate and restart wand_server if the connection to the wavemeter is interrupeted.

Tested on Ubuntu 22.04.5, python 3.10.12, HighFinesse WS8