### PR TITLE
Fix a few small issues

### DIFF
--- a/wand/drivers/high_finesse.py
+++ b/wand/drivers/high_finesse.py
@@ -274,7 +274,7 @@ class WLM:
         self._update_exposure()  # synchronise WLM with self._exposure
         for pipeline_stage in range(3):
             self._trigger_single_measurement()
-            if pipeline_stage == 1:
+            if pipeline_stage == 0:
                 self._update_exposure(self._exp_min)
 
     def _trigger_single_measurement(self):
@@ -342,7 +342,7 @@ class WLM:
           WLMMeasurementStatus and frequency is in Hz.
         """
         if self.simulation:
-            return 0, WLMMeasurementStatus.OKAY
+            return WLMMeasurementStatus.OKAY, 0
 
         # this should never time out, but it does...
         # I've had a long discussion with the HF engineers about why this

--- a/wand/frontend/wand_server.py
+++ b/wand/frontend/wand_server.py
@@ -328,7 +328,7 @@ class WandServer:
 
             exposure = laser_conf["exposure"]
             for ccd, exp in enumerate(exposure):
-                self.wlm.set_exposure(exposure[ccd], ccd)
+                self.wlm.set_exposure(exp, ccd)
 
             if laser_conf.get("osa", "wlm") == "wlm":
                 freq_osa_measurement = self.loop.run_in_executor(
@@ -373,6 +373,7 @@ class WandServer:
             # auto-exposure
             if laser_conf["auto_exposure"]:
                 new_exp = laser_conf["exposure"]
+                old_exp = new_exp.copy()
                 for ccd, peak in enumerate(peaks):
 
                     # don't try to find a suitable exposure for lasers that
@@ -386,7 +387,7 @@ class WandServer:
                         new_exp[ccd] = min(new_exp[ccd], self.exp_max[ccd])
                         new_exp[ccd] = max(new_exp[ccd], self.exp_min[ccd])
 
-                if new_exp != exp:
+                if new_exp != old_exp:
                     self.laser_db[laser]["exposure"] = new_exp
                     self.save_config_file()
 


### PR DESCRIPTION
This PR fixes a few minor issues:

- pipeline_stage in _get_fresh_data method: off by one error. Before, the method would trigger 2 measurements at the saved exposure time, then change exposure time to minimum and do one extra measurement (confirmed in highfinesse longterm graph). Now, it only does one measurement at the saved exposure time, then two more at minimum exp time
- return in get_frequency: Adjust return tuple order in simulation mode to match that of other return statements
- self.wlm.set_exposure: unnecessary lookup of exposure[ccd]
- new_exp != exp: This was always True, because new_exp was a list, exp was an int. Now, were are comparing two lists.

Tested on Ubuntu 22.04.5, python 3.10.12, HighFinesse WS8